### PR TITLE
Fix misplaced footers in HTML pages

### DIFF
--- a/Pending/about.html
+++ b/Pending/about.html
@@ -165,8 +165,6 @@ Fractal
 </div><!--end right hand menu-->
 
 </div><!--end row div-->
-</body>
-
 <footer>
   &copy; 2025 Cartographers of Sanity. Made with <a href="./goofy.html">rust and starlight</a>. &nbsp; &nbsp; &nbsp; &nbsp;
    Our thanks, <a href="scrolls/resonant-contributions.html">contributors! </a><br />
@@ -177,6 +175,5 @@ Fractal
 <li>|<a href="./fire.html">Fire of Thought</a>|</li> 
 </ul>
 </footer>
-
-
+</body>
 </html>

--- a/doctrine/foundations.html
+++ b/doctrine/foundations.html
@@ -168,8 +168,6 @@ Story
 </div><!--end right hand menu-->
 
 </div><!--end row div-->
-</body>
-
 <footer>
   &copy; 2025 Cartographers of Sanity. Made with <a href="../goofy.html">rust and starlight</a>. &nbsp; &nbsp; &nbsp; &nbsp;
    Our thanks, <a href="../scrolls/resonant-contributions.html">contributors! </a><br />
@@ -181,6 +179,5 @@ Story
 <li>|<a href="../fire.html">Fire of Thought</a>|</li> 
 </ul>
 </footer>
-
-
+</body>
 </html>

--- a/fire.html
+++ b/fire.html
@@ -93,8 +93,6 @@ Story
 </div><!--end right hand menu-->
 
 </div><!--end row div-->
-</body>
-
 <footer>
   &copy; 2025 Cartographers of Sanity. Made with <a href="./goofy.html">rust and starlight</a>. &nbsp; &nbsp; &nbsp; &nbsp;
    Our thanks, <a href="scrolls/resonant-contributions.html">contributors! </a><br />
@@ -106,6 +104,5 @@ Story
 <li>|<a href="./fire.html">Fire of Thought</a>|</li> 
 </ul>
 </footer>
-
-
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -105,8 +105,6 @@ Story
 </div><!--end right hand menu-->
 
 </div><!--end row div-->
-</body>
-
 <footer>
   &copy; 2025 Cartographers of Sanity. Made with <a href="./goofy.html">rust and starlight</a>. &nbsp; &nbsp; &nbsp; &nbsp;
    Our thanks, <a href="scrolls/resonant-contributions.html">contributors! </a><br />
@@ -118,7 +116,6 @@ Story
 <li>|<a href="./fire.html">Fire of Thought</a>|</li> 
 </ul>
 </footer>
-
-
+</body>
 </html>
 

--- a/library.html
+++ b/library.html
@@ -169,8 +169,6 @@ Story
 </div><!--end right hand menu-->
 
 </div><!--end row div-->
-</body>
-
 <footer>
   &copy; 2025 Cartographers of Sanity. Made with <a href="./goofy.html">rust and starlight</a>. &nbsp; &nbsp; &nbsp; &nbsp;
    Our thanks, <a href="scrolls/resonant-contributions.html">contributors! </a><br />
@@ -182,7 +180,6 @@ Story
 <li>|<a href="./fire.html">Fire of Thought</a>|</li> 
 </ul>
 </footer>
-
-
+</body>
 </html>
 

--- a/message.html
+++ b/message.html
@@ -296,8 +296,6 @@ Story
 </div><!--end right hand menu-->
 
 </div><!--end row div-->
-</body>
-
 <footer>
   &copy; 2025 Cartographers of Sanity. Made with <a href="./goofy.html">rust and starlight</a>. &nbsp; &nbsp; &nbsp; &nbsp;
    Our thanks, <a href="scrolls/resonant-contributions.html">contributors! </a><br />
@@ -309,7 +307,6 @@ Story
 <li>|<a href="./fire.html">Fire of Thought</a>|</li> 
 </ul>
 </footer>
-
-
+</body>
 </html>
 

--- a/universeistruth.html
+++ b/universeistruth.html
@@ -181,8 +181,6 @@ Story
 </div><!--end right hand menu-->
 
 </div><!--end row div-->
-</body>
-
 <footer>
   &copy; 2025 Cartographers of Sanity. Made with <a href="./goofy.html">rust and starlight</a>. &nbsp; &nbsp; &nbsp; &nbsp;
    Our thanks, <a href="scrolls/resonant-contributions.html">contributors! </a><br />
@@ -194,7 +192,6 @@ Story
 <li>|<a href="./fire.html">Fire of Thought</a>|</li> 
 </ul>
 </footer>
-
-
+</body>
 </html>
 


### PR DESCRIPTION
## Summary
- Move footer elements inside `<body>` tags for all major site pages to ensure valid HTML structure

## Testing
- `tidy -qe index.html`
- `tidy -qe library.html`
- `tidy -qe message.html`
- `tidy -qe fire.html`
- `tidy -qe universeistruth.html`
- `tidy -qe doctrine/foundations.html`
- `tidy -qe Pending/about.html`


------
https://chatgpt.com/codex/tasks/task_e_6894611162f8832a84fd86f60c60ab89